### PR TITLE
Adds messages for Micro-Epsilon IL1900 sensor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,8 @@ set(msg_files
   "msg/FtsStates.msg"
   "msg/FunctionState.msg"
   "msg/FunctionStates.msg"
+  "msg/Ild1900State.msg"
+  "msg/Ild1900States.msg"
   "msg/JedSetCmdValueCmd.msg"
   "msg/JedState.msg"
   "msg/JedStates.msg"

--- a/msg/Ild1900State.msg
+++ b/msg/Ild1900State.msg
@@ -1,0 +1,5 @@
+float64 distance # Distance in m
+uint32 linearized_distance_raw  # Distance in its digital value format
+uint32 timestamp # Timestamp of measurement in ns
+uint32 counter # Counter of measurement
+uint8 error # Type of measurement error if one is present. Zero means no error.

--- a/msg/Ild1900States.msg
+++ b/msg/Ild1900States.msg
@@ -1,0 +1,2 @@
+string[] names
+fcat_msgs/Ild1900State[] states


### PR DESCRIPTION
Adds the ROS messages to transmit the state from the Micro-Epsilon
OptoNCDT ILD1900 laser sensor which measures distance with high
precision.

Test Plan:
Will perform preliminary testing with fcat ROS node.

Reviewers: alex-brinkman, kwehage